### PR TITLE
GridPanel pagination reset after changing column filtering

### DIFF
--- a/lib/netzke/basepack/grid_panel/javascripts/main.js
+++ b/lib/netzke/basepack/grid_panel/javascripts/main.js
@@ -96,8 +96,9 @@
     /* ... and done with columns */
 
     // Filters
+    this.gridFilters = new Ext.ux.grid.GridFilters({filters:filters});
     if (this.enableColumnFilters) {
-     this.plugins.push(new Ext.ux.grid.GridFilters({filters:filters}));
+     this.plugins.push(this.gridFilters);
     }
 
     // Create Ext.data.Record constructor specific for our particular column configuration
@@ -176,7 +177,8 @@
       items : this.bbar ? ["-"].concat(this.bbar) : [],
       store : this.store,
       emptyMsg: 'Empty',
-      displayInfo: true
+      displayInfo: true,
+      plugins: this.gridFilters ? [this.gridFilters] : []
     }) : this.bbar;
 
     // Selection model


### PR DESCRIPTION
Just a small, yet helpful change for setting page nr to '1' after changing anything in grid filter. Done according to the ExtJS source code.
