### PR TITLE
Changed the like query so it doesn't need squeel or meta_where

### DIFF
--- a/lib/netzke/basepack/data_accessor.rb
+++ b/lib/netzke/basepack/data_accessor.rb
@@ -23,7 +23,7 @@ module Netzke
 
             if assoc.klass.column_names.include?(assoc_method)
               # apply query
-              relation = relation.where(:"#{assoc_method}".like => "%#{query}%") if query.present?
+              relation = relation.where(["#{assoc_method} like ?", "%#{query}%"]) if query.present?
               relation.all.map{ |r| [r.id, r.send(assoc_method)] }
             else
               relation.all.map{ |r| [r.id, r.send(assoc_method)] }.select{ |id,value| value =~ /^#{query}/ }


### PR DESCRIPTION
Sorry, I should have changed this with the last commit.  It looks like you had removed some other previous dependencies on meta_where.
