### PR TITLE
Added translation of model name in Grid title

### DIFF
--- a/lib/netzke/basepack/grid_panel.rb
+++ b/lib/netzke/basepack/grid_panel.rb
@@ -228,7 +228,7 @@ module Netzke
       def js_config #:nodoc:
         res = super
         res.merge({
-          :title => res[:title] || self.class.js_properties[:title] || data_class.name.pluralize,
+          :title => res[:title] || self.class.js_properties[:title] || data_class.model_name.human(:count => 2),
           :bbar => config.has_key?(:bbar) ? config[:bbar] : default_bbar,
           :context_menu => config.has_key?(:context_menu) ? config[:context_menu] : default_context_menu,
           :columns => columns(:with_meta => true), # columns


### PR DESCRIPTION
I'm using :count => 2 for pluralization, maybe there's better (more generic) way to do it?
