### PR TITLE
Fixed find_record and documentation

### DIFF
--- a/test/basepack_test_app/app/models/user.rb
+++ b/test/basepack_test_app/app/models/user.rb
@@ -2,4 +2,10 @@ class User < ActiveRecord::Base
   # scope :latest, lambda {|param| where(:created_at.gt => param)}
   belongs_to :role
   has_one :address
+
+  before_destroy :is_admin
+  def is_admin
+    errors.add :base, "Can't delete Admin User." if self.first_name == "Admin"
+    errors.blank?
+  end
 end

--- a/test/basepack_test_app/features/grid_panel.feature
+++ b/test/basepack_test_app/features/grid_panel.feature
@@ -53,6 +53,17 @@ Scenario: Deleting a record
   Then a user should not exist with first_name: "Anton"
 
 @javascript
+Scenario: Try deleting an undeletable record
+  Given a user exists with first_name: "Admin", last_name: "Admin"
+  When I go to the UserGrid test page
+  And I select all rows in the grid
+  And I press "Delete"
+  Then I should see "Are you sure?"
+  When I press "Yes"
+  Then I should see "Can't delete Admin User"
+  Then a user should exist with first_name: "Admin"
+
+@javascript
 Scenario: Multi-editing records
   Given a user exists with first_name: "Carlos", last_name: "Castaneda"
   And a user exists with first_name: "Herman", last_name: "Hesse"


### PR DESCRIPTION
configuration enable_context_menu is not needed, context_menu => false is documented and can be used instead

changed find_record method to make it work with differently named primary keys (not named id)
