### PR TITLE
Fix "undefined method `find_all_by_id' for #<Class" while updating records with custom primary keys

### DIFF
--- a/lib/netzke/basepack/data_adapters/active_record_adapter.rb
+++ b/lib/netzke/basepack/data_adapters/active_record_adapter.rb
@@ -130,7 +130,7 @@ module Netzke::Basepack::DataAdapters
     end
 
     def find_record(id)
-      @model_class.find_all_by_id(id).first
+      @model_class.where(@model_class.primary_key => id).first
     end
 
     # Build a hash of foreign keys and the associated model


### PR DESCRIPTION
The previous code would result in this error:
NoMethodError Exception: undefined method `find_all_by_id' for #<Class...
