### PR TITLE
Renamed bulkExecute in FormPanel and GridPanel to netzkeBulkExecute

### DIFF
--- a/lib/netzke/basepack/form_panel/javascripts/form_panel.js
+++ b/lib/netzke/basepack/form_panel/javascripts/form_panel.js
@@ -144,13 +144,13 @@
           failure: function(form, action){
             var respObj = Ext.decode(action.response.responseText);
             delete respObj.success;
-            this.bulkExecute(respObj);
+            this.netzkeBulkExecute(respObj);
             this.setLoading(false);
           },
           success: function(form, action) {
             var respObj = Ext.decode(action.response.responseText);
             delete respObj.success;
-            this.bulkExecute(respObj);
+            this.netzkeBulkExecute(respObj);
           },
           scope: this
         });

--- a/lib/netzke/basepack/grid_panel/javascripts/grid_panel.js
+++ b/lib/netzke/basepack/grid_panel/javascripts/grid_panel.js
@@ -249,7 +249,7 @@
             response = response.result;
             if (response) { // or did we have an exception?
               Ext.each(['data', 'total', 'success'], function(property){delete response[property];});
-              this.bulkExecute(response);
+              this.netzkeBulkExecute(response);
             }
           },
           scope: this
@@ -283,7 +283,7 @@
     var dataRecords = this.getStore().getProxy().getReader().read(data);
     this.getStore().loadData(dataRecords.records);
     Ext.each(['data', 'total', 'success'], function(property){delete data[property];}, this);
-    this.bulkExecute(data);
+    this.netzkeBulkExecute(data);
   },
 
   // Tries editing the first editable (i.e. not hidden, not read-only) sell


### PR DESCRIPTION
In netzke-core/javascripts/base.js the bulkExecute function is now called netzkeBulkExecute.

I modified the FormPanel and GridPanel accordingly.
