### PR TITLE
Add support for validation errors on before_destroy

### DIFF
--- a/test/basepack_test_app/app/models/user.rb
+++ b/test/basepack_test_app/app/models/user.rb
@@ -24,6 +24,14 @@ class User < ActiveRecord::Base
   # scope :latest, lambda {|param| where(:created_at.gt => param)}
   belongs_to :role
   has_one :address
+  
+  before_destroy :is_admin
+ 
+  def is_admin
+    errors.add :base, "Can't delete Admin User." if self.first_name == "Admin"
+    errors.blank?
+  end
+
 end
 
 end

--- a/test/basepack_test_app/features/grid_panel.feature
+++ b/test/basepack_test_app/features/grid_panel.feature
@@ -52,6 +52,17 @@ Scenario: Deleting a record
   And a user should not exist with first_name: "Maxim"
 
 @javascript
+Scenario: Try deleting an undeletable record
+  Given a user exists with first_name: "Admin", last_name: "Admin"
+  When I go to the UserGrid test page
+  And I select all rows in the grid
+  And I press "Delete"
+  Then I should see "Are you sure?"
+  When I press "Yes"
+  Then I should see "Can't delete Admin User"
+  Then a user should exist with first_name: "Admin"
+
+@javascript
 Scenario: Multi-editing records
   Given a user exists with first_name: "Carlos", last_name: "Castaneda"
   And a user exists with first_name: "Herman", last_name: "Hesse"


### PR DESCRIPTION
By returning false from a before_destroy hook the deletion can be prevented. Yet currently netzke would still display "Deleted n records" even if the delete failed.

These changes return the validation error messages as netzke_feedback.

PS: The fix is just for 0-7. I'll submit a pull request for 0-8 as soon as I have the test env set up for it.
