### PR TITLE
Tweak grid in order to use the store's autoSync option

### DIFF
--- a/lib/netzke/basepack/grid/javascripts/grid.js
+++ b/lib/netzke/basepack/grid/javascripts/grid.js
@@ -141,6 +141,14 @@
         this.on('columnshow', this.onColumnShow, this);
       }
     }, this);
+
+    if(this.getStore().autoSync){
+      // if autoSync is enabled, cancel event and call onApply() instead
+      this.getStore().on('beforesync', function(){
+        this.onApply();
+        return false;
+      }, this);
+    }
   },
 
   processColumns: function() {


### PR DESCRIPTION
By default the Ext JS store calls the get_data endpoint. To use the
autoSync option, the sync event gets cancelled and calls the onApply
method instead.
