### PR TITLE
Fix bug in Forms when virtual attribute has assignment function in Model

### DIFF
--- a/lib/netzke/basepack/columns.rb
+++ b/lib/netzke/basepack/columns.rb
@@ -171,7 +171,7 @@ module Netzke
         final_columns.select do |c|
           !c.getter.nil? || !c.setter.nil? ||
           data_adapter.attribute_names.include?(c[:name]) ||
-          data_class.instance_methods.include?("#{c[:name]}=") ||
+          data_class.instance_methods.include?(:"#{c[:name]}=") ||
           association_attr?(c[:name])
         end
       end


### PR DESCRIPTION
Sorry, I didn't find this one until after you merged the last pull request...

There is another bug in columns_taken_over_to_forms that prevents virtual attributes with an assignment function in the model (as opposed to a configured getter/setter) from being shown in Forms.  This commit fixes that.

Thanks!
