### PR TITLE
Make combobox search in entire virtual attribute

### DIFF
--- a/lib/netzke/basepack/data_adapters/active_record_adapter.rb
+++ b/lib/netzke/basepack/data_adapters/active_record_adapter.rb
@@ -126,7 +126,7 @@ module Netzke::Basepack::DataAdapters
           relation.all.map{ |r| [r.id, r.send(assoc_method)] }
         else
           # an expensive search!
-          relation.all.map{ |r| [r.id, r.send(assoc_method)] }.select{ |id,value| value =~ /^#{query}/ }
+          relation.all.map{ |r| [r.id, r.send(assoc_method)] }.select{ |id,value| value.include?(query) }
         end
 
       else


### PR DESCRIPTION
I've made a change to get a combobox to search in the entire value of a virtual attribute. I have a virtual attribute called full_name which is built up by last_name, first_name - company - customer_id. So if a colleague would want to look someone up in the previous Netzke approach, they would _have_ to use the last_name. Now they can also find customers by customer_id or the company name.

I've been benchmarking my way through the options, especially when I read this:

http://www.rubyops.net/ruby-methods-vs-regex

And I've made the attached commit and pull request.

As you can see in the following benchmarks, include(query) is a little faster faster than =~ /^#{query}/ and it will display more results :)

```
irb(main):022:0> Benchmark.bm do |x|
irb(main):023:1* x.report {10000.times { 'foobarfoo'.include?('bar') }}
irb(main):024:1> x.report {10000.times { 'foobarfoo' =~ /bar/ }}
irb(main):025:1> x.report {10000.times { 'foobarfoo' =~ /^foo/ }}
irb(main):026:1> end
       user     system      total        real
   0.000000   0.000000   0.000000 (  0.005183)
   0.010000   0.000000   0.010000 (  0.007409)
   0.010000   0.000000   0.010000 (  0.007697)
```
