### PR TITLE
Fix grid.js for readonly

### DIFF
--- a/lib/netzke/basepack/grid/javascripts/grid.js
+++ b/lib/netzke/basepack/grid/javascripts/grid.js
@@ -109,7 +109,7 @@
     // Process selectionchange event to enable/disable actions
     this.getSelectionModel().on('selectionchange', function(selModel){
       if (this.actions.del) this.actions.del.setDisabled(!selModel.hasSelection() || this.prohibitDelete);
-      if (this.actions.edit) this.actions.edit.setDisabled(!this.enableEditInForm && (selModel.getCount() != 1 || this.prohibitUpdate));
+      if (this.actions.edit) this.actions.edit.setDisabled(selModel.getCount() != 1 || this.prohibitUpdate);
     }, this);
 
     // WIP: GridView


### PR DESCRIPTION
Small fix for readonly grid, i think editInForm should not affect the edit action, also because cell editing disabled before when prohibitUpdate.
