### PR TITLE
Improve combo queries, filtering and sorting

### DIFF
--- a/lib/netzke/basepack/data_adapters/active_record_adapter.rb
+++ b/lib/netzke/basepack/data_adapters/active_record_adapter.rb
@@ -122,7 +122,9 @@ module Netzke::Basepack::DataAdapters
 
         if assoc.klass.column_names.include?(assoc_method)
           # apply query
-          relation = relation.where(["#{assoc_method} like ?", "%#{query}%"]) if query.present?
+          assoc_arel_table = assoc.klass.arel_table
+
+          relation = relation.where(assoc_arel_table[assoc_method].matches("%#{query}%"))  if query.present?
           relation.all.map{ |r| [r.id, r.send(assoc_method)] }
         else
           # an expensive search!


### PR DESCRIPTION
This fixes the following things:

Unlike MySQL, Postgres treats LIKE queries as case sensitive. Using arel's 'matches' predicate takes into account such differences and uses ILIKE on Postgres (case insensitive). Fixed this for column filtering and combo_box queries.

The equality column filter for dates didn't return any records as the date is being cast to datetime resulting in a time of 00:00:00 (technically it returns records for that time but I assume that is not the intended behaviour).
