### PR TITLE
Make combobox virtual attribute lookup case-insensitive

### DIFF
--- a/lib/netzke/basepack/data_adapters/active_record_adapter.rb
+++ b/lib/netzke/basepack/data_adapters/active_record_adapter.rb
@@ -134,8 +134,9 @@ module Netzke::Basepack::DataAdapters
           relation = relation.where(assoc_arel_table[assoc_method].matches("%#{query}%"))  if query.present?
           relation.all.map{ |r| [r.id, r.send(assoc_method)] }
         else
+          query.downcase!
           # an expensive search!
-          relation.all.map{ |r| [r.id, r.send(assoc_method)] }.select{ |id,value| value.include?(query) }
+          relation.all.map{ |r| [r.id, r.send(assoc_method)] }.select{ |id,value| value.downcase.include?(query) }
         end
 
       else


### PR DESCRIPTION
With this fix, the lookup on a virtual attribute becomes case-insensitive, just like the MySQL lookup is.
