### PR TITLE
Handle selectionchange in EXT JS 4.2 correctly

### DIFF
--- a/lib/netzke/basepack/grid/javascripts/grid.js
+++ b/lib/netzke/basepack/grid/javascripts/grid.js
@@ -94,7 +94,7 @@
     if (this.enableEditInForm && !this.prohibitUpdate) {
       this.getSelectionModel().on('selectionchange', function(selModel, selected){
         var disabled;
-        if (selected.length === 0) { // empty?
+        if (selected === undefined || selected.length === 0) { // empty?
           disabled = true;
         } else {
           // Disable "edit in form" button if new record is present in selection


### PR DESCRIPTION
In EXT JS 4.2 the selectionchange event is called after a grid reload with a _selected_ param that is undefined. This makes the listener handle the that correctly.
