### PR TITLE
Added safeguard for grids which don't autoload their store

### DIFF
--- a/lib/netzke/basepack/grid/javascripts/remember_selection.js
+++ b/lib/netzke/basepack/grid/javascripts/remember_selection.js
@@ -7,7 +7,7 @@
     this.selectedRecords = this.getSelectionModel().getSelection();
   },
   refreshSelection: function() {
-    if (0 >= this.selectedRecords.length) {
+    if (!this.selectedRecords.length || 0 >= this.selectedRecords.length) {
       return;
     }
 


### PR DESCRIPTION
I have a few grids configured with c.data_store = { auto_load: false } ...
this.selectedRecords.length is undefined as long as the store is not loaded and thus the line breaks without safeguarding against undefined.
