### PR TITLE
js error on grid with column_filters_available = false

### DIFF
--- a/lib/netzke/basepack/grid/javascripts/grid.js
+++ b/lib/netzke/basepack/grid/javascripts/grid.js
@@ -161,15 +161,16 @@
       this.getView().on('refresh', this.refreshSelection, this);
     }
     // In EXT JS 4.1 the filters object isn't initialized
-    if (this.filters === undefined){
+    if (this.enableColumnFilters && ( this.filters === undefined)){
       view = this.getView();
       view.initFeatures();
+      var f = false;
       Ext.each(view.features, function(item, index, allItems){
         if (item.ftype && item.ftype == 'filters'){
           f = item;
         }
       });
-      if(f.filters === undefined || f.filters.items.length == 0){
+      if(f && (f.filters === undefined || f.filters.items.length == 0)){
         f.createFilters();
       }
     }else{


### PR DESCRIPTION
Without this in js we can see error bc var f will be not initialized
