### PR TITLE
Has_one relation on update

### DIFF
--- a/lib/netzke/basepack/data_adapters/active_record_adapter.rb
+++ b/lib/netzke/basepack/data_adapters/active_record_adapter.rb
@@ -263,13 +263,11 @@ module Netzke::Basepack::DataAdapters
             assoc_method = split.last
             if assoc
               if assoc.macro == :has_one
-                assoc_instance = r.send(assoc.name)
-                if assoc_instance
-                  assoc_instance.send("#{assoc_method}=", v)
-                  assoc_instance.save # what should we do when this fails?..
-                else
-                  # what should we do in this case?
-                end
+                #here we just set the new new relationship, we
+                # do not change nested attributes here
+                r.send "#{assoc.name}=", assoc.klass.find v
+                #this is excess, at least for checked examples
+                r.save # what should we do when this fails?..
               else
 
                 # set the foreign key to the passed value

--- a/lib/netzke/basepack/data_adapters/active_record_adapter.rb
+++ b/lib/netzke/basepack/data_adapters/active_record_adapter.rb
@@ -100,7 +100,7 @@ module Netzke::Basepack::DataAdapters
     end
 
     def get_assoc_property_type assoc_name, prop_name
-      if prop_name && assoc = @model_class.reflect_on_association(assoc_name)
+      if prop_name && assoc = @model_class.reflect_on_association(assoc_name.to_sym)
         assoc_column = assoc.klass.columns_hash[prop_name.to_s]
         assoc_column.try(:type)
       end

--- a/lib/netzke/basepack/data_adapters/active_record_adapter.rb
+++ b/lib/netzke/basepack/data_adapters/active_record_adapter.rb
@@ -260,12 +260,16 @@ module Netzke::Basepack::DataAdapters
           if split.size == 2
             # search for association and assign it to r
             assoc = @model_class.reflect_on_association(split.first.to_sym)
-            assoc_method = split.last
             if assoc
-              if assoc.macro == :has_one
+              if (assoc.macro == :has_one) && attribute_mass_assignable?(assoc.foreign_key, role)
                 #here we just set the new new relationship, we
                 # do not change nested attributes here
-                r.send "#{assoc.name}=", assoc.klass.find v
+                assoc_instance = begin
+                  assoc.klass.find v
+                rescue ActiveRecord::RecordNotFound
+                  nil
+                end
+                r.send "#{assoc.name}=", assoc_instance
                 #this is excess, at least for checked examples
                 r.save # what should we do when this fails?..
               else

--- a/lib/netzke/basepack/data_adapters/active_record_adapter.rb
+++ b/lib/netzke/basepack/data_adapters/active_record_adapter.rb
@@ -261,17 +261,19 @@ module Netzke::Basepack::DataAdapters
             # search for association and assign it to r
             assoc = @model_class.reflect_on_association(split.first.to_sym)
             if assoc
-              if (assoc.macro == :has_one) && attribute_mass_assignable?(assoc.foreign_key, role)
-                #here we just set the new new relationship, we
-                # do not change nested attributes here
-                assoc_instance = begin
-                  assoc.klass.find v
-                rescue ActiveRecord::RecordNotFound
-                  nil
+              if assoc.macro == :has_one
+                if attribute_mass_assignable?(split.first, role) || attribute_mass_assignable?(assoc.foreign_key, role)
+                  #here we just set the new new relationship, we
+                  # do not change nested attributes here
+                  assoc_instance = begin
+                    assoc.klass.find(v)
+                  rescue ActiveRecord::RecordNotFound
+                    nil
+                  end
+                  r.send "#{assoc.name}=", assoc_instance
+                  #this is excess, at least for checked examples
+                  r.save
                 end
-                r.send "#{assoc.name}=", assoc_instance
-                #this is excess, at least for checked examples
-                r.save # what should we do when this fails?..
               else
 
                 # set the foreign key to the passed value


### PR DESCRIPTION
Saving only relation when no nested_attribute is set.
Added check on attribute_mass_assignable?
Still works for has_one, :through