### PR TITLE
composite_primary_keys workaround

### DIFF
--- a/lib/netzke/basepack/data_adapters/active_record_adapter.rb
+++ b/lib/netzke/basepack/data_adapters/active_record_adapter.rb
@@ -238,6 +238,10 @@ module Netzke::Basepack::DataAdapters
         else
           r.send("#{assoc.options[:foreign_key] || assoc.name.to_s.foreign_key}")
         end
+      # the composite_primary_keys gem produces [Key1,Key2...] and [Value1,Value2...]
+      # on primary_key and id requests. Basepack::AttrConfig converts the keys-array to an String.
+      elsif r.class.primary_key.try(:to_s) == a[:name]
+        r.id # return 'val1,val2...' on 'key1,key2...' composite_primary_keys
       end
 
       # a work-around for to_json not taking the current timezone into account when serializing ActiveSupport::TimeWithZone


### PR DESCRIPTION
The composite_primary_keys gem responds with
[Key1,Key2...] and [Value1,Value2...]
on primary_key and id requests.
Basepack::AttrConfig converts the keys Array to String.
This workaround will transport the values to extjs
as a comma-separated string too.
