### PR TITLE
solves ActiveModel::ForbiddenAttributesError with scope in component configuration (rails 4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .DS_Store
 *.log
 pkg

--- a/lib/netzke/basepack/grid/endpoints.rb
+++ b/lib/netzke/basepack/grid/endpoints.rb
@@ -85,6 +85,17 @@ module Netzke
         # Operations:
         #   create, read, update, delete
         def attempt_operation(op, data, this)
+          # if data is ActionController::Parameters and a scope is in the component config
+          # then ran this in an ActiveModel::ForbiddenAttributesError (rails 4 strong parameters)
+          # solution: in this case convert ActionController::Parameters to a Hash
+          if data.is_a?ActionController::Parameters
+            dataHash = {}
+            data.each do |k,v|
+              #preserve keys as symbol
+              dataHash[k.to_sym] = v
+            end
+            data = dataHash
+          end
           if !config["prohibit_#{op}"]
             res = send(op, data)
             this.netzke_set_result res


### PR DESCRIPTION
Grid ran in an ActiveModel::ForbiddenAttributesError (rails 4 strong parameters) when the  component has  a scope configured. (config[:scope] will later be merged to the params object that is an ActionController::Parameters object. - As the scope is database related this will be denied with ActiveModel::ForbiddenAttributesError)
solution: convert ActionController::Parameters to a Hash - then the error is gone

related to #159 