### PR TITLE
add dateFormat to date attrType to fix timezone-related display bug

### DIFF
--- a/lib/netzke/basepack/grid/javascripts/grid.js
+++ b/lib/netzke/basepack/grid/javascripts/grid.js
@@ -213,6 +213,11 @@
         }
       };
 
+      if (c.attrType == 'date') {
+        // If no dateFormat given for date attrType, Timezone translation can subtract zone offset from 00:00:00 causing previous day.
+        fieldConfig.dateFormat = 'Y-m-d';
+      };
+
       // because checkcolumn doesn't care about editor (not) being set, we need to explicitely set readOnly here
       if (c.xtype == 'checkcolumn' && !c.editor) {
         c.readOnly = true;


### PR DESCRIPTION
Sencha docs explain how it is highly recommended to specify a dateFormat. Without this, date fields return the previous day than what is in the database - a result of a Timezone translation issue, subtracting local timezone offset from 00:00:00 resulting in previous day for any locale west of GMT.