### PR TITLE
grid query seems to be broken if more than two filter procs applied

### DIFF
--- a/lib/netzke/basepack/data_adapters/active_record_adapter.rb
+++ b/lib/netzke/basepack/data_adapters/active_record_adapter.rb
@@ -347,11 +347,10 @@ module Netzke::Basepack::DataAdapters
       if params[:filters]
         and_query = params[:filters]
         and_query.each do |q|
-          if prok = q.delete(:proc)
-            relation = prok.call(relation, q[:value], q[:operator])
-            and_query.delete(q)
-          end
+          relation = q[:proc].call(relation, q[:value], q[:operator]) if q[:proc]
         end
+
+        and_query.delete_if{|q| q[:proc] }
 
         # apply other, non-Proc filters
         relation = relation.where(predicates_for_and_conditions(and_query))

--- a/spec/features/javascripts/grid/filters.js.coffee
+++ b/spec/features/javascripts/grid/filters.js.coffee
@@ -30,7 +30,13 @@ describe 'Grid filter functionality', ->
       enableColumnFilter "notes", "read", ->
         expect(grid("Books").getStore().getCount()).to.eql 2
         done()
-
+  it 'filters by title_or_notes and price_or_exemplars', (done) ->
+    wait ->
+      grid().filters.clearFilters()
+      enableColumnFilter "title_or_notes", "read", ->
+        enableColumnFilter "price_or_exemplars", 5, ->
+          expect(grid("Books").getStore().getCount()).to.eql 1
+          done()
   # Do not ask me why filter.setValue(), when called on the TriFilter, does not send filter params to the server.
   # What's left to do? Test manually.
   # it 'filters by float', (done) ->

--- a/spec/rails_app/app/components/grid/filters.rb
+++ b/spec/rails_app/app/components/grid/filters.rb
@@ -7,6 +7,11 @@ class Grid::Filters < Netzke::Basepack::Grid
         name: :title_or_notes,
         getter: ->(foo) { 'dummy' },
         filter_with: ->(rel, value, op) {rel.where("title like ? or notes like ?", "%#{value}%", "%#{value}%")}
+      },
+      {
+        name: :price_or_exemplars,
+        getter: ->(rel) { 5 },
+        filter_with: ->(rel, value, op) { rel.where("price > ? or exemplars > ?", value, value) }
       }
     ]
   end


### PR DESCRIPTION
if i.e. two filter procs have to be applied, the first one will be applied to the relation, but then the second one will not be applied. results in an error because the second filter will now be seen as non-proc filter. 