### PR TITLE
fix bug in showing validation errors on update

### DIFF
--- a/lib/netzke/grid/base/client/extensions.js
+++ b/lib/netzke/grid/base/client/extensions.js
@@ -95,11 +95,12 @@ Ext.define('Netzke.Grid.Proxy', {
   },
 
   update: function(op, callback, scope) {
-    var data = Ext.Array.map(op.getRecords(), function(r) { return r.getData(); });
+    var records = op.getRecords();
+    var data = Ext.Array.map(records, function(r) { return r.getData(); });
 
     this.grid.server.update(data, function(res) {
       var errors = [];
-      Ext.each(op.records, function(r) {
+      Ext.each(records, function(r) {
         var rid = r.getId(),
             recordData = res[rid].record,
             error = res[rid].error;

--- a/spec/features/javascripts/grid/crud_inline.js.coffee
+++ b/spec/features/javascripts/grid/crud_inline.js.coffee
@@ -85,6 +85,20 @@ describe 'Grid::CrudInline', ->
       selectFirstRow()
       expect(rowDisplayValues()).to.eql ['Herman Hesse', 'Damian']
 
+  it 'gives a validation error when trying to update a record with invalid value', ->
+    wait().then ->
+      updateRecord title: ''
+      click button 'Apply'
+      wait()
+    .then ->
+      expectToSee anywhere "Title can't be blank"
+      expect(grid('Books').getStore().getModifiedRecords().length).to.eql(1)
+      editLastRow {title: 'Foo'}
+      click button 'Apply'
+      wait()
+    .then ->
+      expect(grid('Books').getStore().getModifiedRecords().length).to.eql(0)
+
   it 'gives a validation error when trying to add an invalid record', ->
     wait().then ->
       addRecord exemplars: 3 # title is missing

--- a/spec/features/javascripts/grid/crud_inline.js.coffee
+++ b/spec/features/javascripts/grid/crud_inline.js.coffee
@@ -87,7 +87,7 @@ describe 'Grid::CrudInline', ->
 
   it 'gives a validation error when trying to update a record with invalid value', ->
     wait().then ->
-      updateRecord title: ''
+      editLastRow title: ''
       click button 'Apply'
       wait()
     .then ->


### PR DESCRIPTION
The property op.records is empty for me (on ext-5.1.1).

Using the same record array that is used to send the update request fixes the issue.